### PR TITLE
CMake targets fixes for optional vs. required packages

### DIFF
--- a/build/DXUT-config.cmake.in
+++ b/build/DXUT-config.cmake.in
@@ -5,7 +5,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Opt-targets.cmake)
 include(CMakeFindDependencyMacro)
 
 if(MINGW)
-    find_dependency(directxmath CONFIG)
+    find_dependency(directxmath)
+else()
+    find_package(directxmath CONFIG QUIET)
 endif()
 
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
With the changes to make use of DirectXMath 'optional' for VCPKG scenarios unless using MinGW, the generated targets file needed more robust handling of these targets.