### PR TITLE
Update build pipelines for recent changes to windows-2022 ADO images

### DIFF
--- a/build/DXUT-GitHub-MinGW.yml
+++ b/build/DXUT-GitHub-MinGW.yml
@@ -41,10 +41,6 @@ pool:
 variables:
   VCPKG_CMAKE_DIR: '$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake'
   GITHUB_PAT: $(GITHUBPUBLICTOKEN)
-  URL_MINGW32: https://github.com/brechtsanders/winlibs_mingw/releases/download/12.2.0-14.0.6-10.0.0-ucrt-r2/winlibs-i686-posix-dwarf-gcc-12.2.0-llvm-14.0.6-mingw-w64ucrt-10.0.0-r2.zip
-  HASH_MINGW32: 'fcd1e11b896190da01c83d5b5fb0d37b7c61585e53446c2dab0009debc3915e757213882c35e35396329338de6f0222ba012e23a5af86932db45186a225d1272'
-  URL_MINGW64: https://github.com/brechtsanders/winlibs_mingw/releases/download/12.2.0-14.0.6-10.0.0-ucrt-r2/winlibs-x86_64-posix-seh-gcc-12.2.0-llvm-14.0.6-mingw-w64ucrt-10.0.0-r2.zip
-  HASH_MINGW64: '6694e552d73195b57f283645ab78cb0180f4d957b5501a83e6b4f2679dfad13a8e85e1df6f7b061ea4431fbd2bb0c8f2ac3a1dd810489c1a8d1665b226df8092'
 
 jobs:
 - job: MINGW32_BUILD
@@ -68,29 +64,6 @@ jobs:
         echo ##vso[task.setvariable variable=VCPKG_DEFAULT_HOST_TRIPLET;]x86-mingw-static
 
       workingDirectory: $(Build.SourcesDirectory)\vcpkg
-  - task: PowerShell@2
-    # We install GCC 12.2 as the MS Hosted only offers 11.2
-    displayName: Install MinGW32
-    inputs:
-      targetType: inline
-      script: |
-        $ProgressPreference = 'SilentlyContinue'
-        Write-Host "Downloading winlibs..."
-        Invoke-WebRequest -Uri "$(URL_MINGW32)" -OutFile "gw32.zip"
-        Write-Host "Downloaded."
-        $fileHash = Get-FileHash -Algorithm SHA512 gw32.zip | ForEach { $_.Hash} | Out-String
-        $filehash = $fileHash.Trim()
-        Write-Host "##[debug]SHA512: " $fileHash
-        if ($fileHash -ne '$(HASH_MINGW32)') {
-            Write-Error -Message "##[error]Computed hash does not match!" -ErrorAction Stop
-        }
-        Write-Host "Extracting winlibs..."
-        Expand-Archive -LiteralPath 'gw32.zip'
-        Write-Host "Extracted."
-        Write-Host "Added to path: $env:BUILD_SOURCESDIRECTORY\gw32\mingw32\bin"
-        Write-Host "##vso[task.prependpath]$env:BUILD_SOURCESDIRECTORY\gw32\mingw32\bin"
-
-      workingDirectory: $(Build.SourcesDirectory)
   - task: CmdLine@2
     displayName: GCC version
     inputs:
@@ -141,28 +114,6 @@ jobs:
         echo ##vso[task.setvariable variable=VCPKG_DEFAULT_HOST_TRIPLET;]x64-mingw-static
 
       workingDirectory: $(Build.SourcesDirectory)\vcpkg
-  - task: PowerShell@2
-    displayName: Install MinGW-W64
-    inputs:
-      targetType: inline
-      script: |
-        $ProgressPreference = 'SilentlyContinue'
-        Write-Host "Downloading winlibs..."
-        Invoke-WebRequest -Uri "$(URL_MINGW64)" -OutFile "gw64.zip"
-        Write-Host "Downloaded."
-        $fileHash = Get-FileHash -Algorithm SHA512 gw64.zip | ForEach { $_.Hash} | Out-String
-        $filehash = $fileHash.Trim()
-        Write-Host "##[debug]SHA512: " $fileHash
-        if ($fileHash -ne '$(HASH_MINGW64)') {
-            Write-Error -Message "##[error]Computed hash does not match!" -ErrorAction Stop
-        }
-        Write-Host "Extracting winlibs..."
-        Expand-Archive -LiteralPath 'gw64.zip'
-        Write-Host "Extracted."
-        Write-Host "Added to path: $env:BUILD_SOURCESDIRECTORY\gw64\mingw64\bin"
-        Write-Host "##vso[task.prependpath]$env:BUILD_SOURCESDIRECTORY\gw64\mingw64\bin"
-
-      workingDirectory: $(Build.SourcesDirectory)
   - task: CmdLine@2
     displayName: GCC version
     inputs:


### PR DESCRIPTION
The latest **windows-2022** ADO image upgraded MinGW to 12.2, so I no longer need to explicitly install it for that pipeline.